### PR TITLE
buildbot: Change git repo url from git:// to https://

### DIFF
--- a/roles/buildbot/files/buildsteps_feed.py
+++ b/roles/buildbot/files/buildsteps_feed.py
@@ -21,7 +21,7 @@ def is_no_release(step):
 
 
 feed_checkoutSource = Git(
-    repourl='git://github.com/freifunk-berlin/falter-repo_builder',
+    repourl='https://github.com/freifunk-berlin/falter-repo_builder',
     branch="master",   # this can get changed by html.WebStatus.change_hook()
                        # by notification from GitHub of a commit
     workdir="build",

--- a/roles/buildbot/files/buildsteps_image.py
+++ b/roles/buildbot/files/buildsteps_image.py
@@ -24,7 +24,7 @@ def is_release_step(step):
 
 
 cmd_checkoutSource = Git(
-    repourl='git://github.com/freifunk-berlin/falter-builter',
+    repourl='https://github.com/freifunk-berlin/falter-builter',
     branch="master",   # this can get changed by html.WebStatus.change_hook()
                        # by notification from GitHub of a commit
     workdir="build/falter-builter",


### PR DESCRIPTION
Github started warning about git:// being deprecated for unauthenticated
uses, so let's switch to https:// instead.