### PR TITLE
Check if pool is alive before running query

### DIFF
--- a/roles/ff_wizard/templates/wizard-config.cfg.j2
+++ b/roles/ff_wizard/templates/wizard-config.cfg.j2
@@ -9,6 +9,7 @@ SECRET_KEY = '{{ ff_wizard_secret }}'
 
 SQLALCHEMY_DATABASE_URI = '{{ ff_wizard_connectionstring }}'
 SQLALCHEMY_TRACK_MODIFICATIONS = True
+SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
 
 MAIL_FROM = 'no-reply@config.berlin.freifunk.net'
 


### PR DESCRIPTION
This should fix the occasional "OperationalError: (psycopg2.OperationalError) SSL connection has been closed unexpectedly"


https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping