### PR TITLE
roles: Add role podman

### DIFF
--- a/play.yml
+++ b/play.yml
@@ -15,6 +15,7 @@
   hosts: buildbot
   become: true
   roles:
+    - podman
     - buildbot
     - geerlingguy.nginx
     - systemli.letsencrypt

--- a/roles/podman/handlers/main.yml
+++ b/roles/podman/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: podman | reboot
+  # after setting up podman, we need to reboot, so the dbus-user-connection module gets working
+  ansible.builtin.reboot:
+    reboot_timeout: 300
+
+...

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: install podman and its dependencies for rootless setup
+  apt:
+    name:
+      - slirp4netns
+      - fuse-overlayfs
+      - dbus-user-session
+      - uidmap
+      - podman
+      - skopeo
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  notify: podman | reboot
+
+...


### PR DESCRIPTION
This role installs podman in a rootless setup on a debian 11 machine.

Signed-off-by: Martin Hübner <martin.hubner@web.de>