### PR TITLE
add caddy for monitor.berlin.freifunk.net

### DIFF
--- a/inventory/host_vars/monitor.berlin.freifunk.net
+++ b/inventory/host_vars/monitor.berlin.freifunk.net
@@ -1,0 +1,2 @@
+---
+caddy_caddyfile: Caddyfile_monitor.j2

--- a/play.yml
+++ b/play.yml
@@ -47,3 +47,9 @@
     - nipap
     - caddy
     - ff_wizard
+
+- name: Set up monitoring server
+  hosts: monitor.berlin.freifunk.net
+  become: true
+  roles:
+    - caddy

--- a/templates/Caddyfile_monitor.j2
+++ b/templates/Caddyfile_monitor.j2
@@ -1,0 +1,10 @@
+monitor.berlin.freifunk.net  {
+    root * /srv/www/monitor.berlin.freifunk.net
+    encode gzip zstd
+    php_fastcgi unix//run/php/php-fpm.sock
+    file_server
+}
+
+
+
+


### PR DESCRIPTION
replace the installed nginx+certbot on monitor.ff... with caddy, similar to the config server etc.
