### PR TITLE
Buildbot releases

### DIFF
--- a/play.yml
+++ b/play.yml
@@ -30,13 +30,13 @@
     - geerlingguy.nginx
     - systemli.letsencrypt
 
-- name: Set up buildbot workers
-  hosts: buildbotworker
-  become: true
-  roles:
-    - alvistack.podman
-    - podman_fix
-    - buildbot_worker
+# - name: Set up buildbot workers
+#   hosts: buildbotworker
+#   become: true
+#   roles:
+#     - alvistack.podman
+#     - podman_fix
+#     - buildbot_worker
 
 - name: Set up config server
   hosts: configserver

--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -117,14 +117,14 @@ cat build/targets-%(prop:branch)s.txt \
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
     # TODO: This linking stuff does not work reliably
-    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:falterVersion)s/packages/")
-    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/packages/%(prop:origbuildnumber)s/*")
+    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:falterVersion)s/packages")
+    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/packages/%(prop:origbuildnumber)s")
     f.addStep(
         steps.MasterShellCommand(
             name="change symlinks to new artifacts",
             haltOnFailure=True,
             command=["sh", "-c", util.Interpolate(
-                "rm -vrf %(kw:symlinksrc)s && mkdir -p %(kw:symlinksrc)s && ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
+                "rm -vrf %(kw:symlinksrc)s && ln -s  -T %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
 
     return f
 

--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -116,31 +116,15 @@ cat build/targets-%(prop:branch)s.txt \
         steps.ShellCommand(
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
-
-    # TODO: Make the following 3 steps better by having one symlink as the
-    # packages dir, not multiple within the packages dir.
+    # TODO: This linking stuff does not work reliably
     symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:falterVersion)s/packages/")
     symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/packages/%(prop:origbuildnumber)s/*")
     f.addStep(
         steps.MasterShellCommand(
-            name="remove symlinks to old artifacts",
+            name="change symlinks to new artifacts",
             haltOnFailure=True,
             command=["sh", "-c", util.Interpolate(
-                "rm -vrf %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
-    f.addStep(
-        steps.MasterShellCommand(
-            name="recreate directory for symlinks",
-            haltOnFailure=True,
-            command=["sh", "-c", util.Interpolate(
-                "mkdir -p %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
-    f.addStep(
-        steps.MasterShellCommand(
-            name="symlink artifacts to url",
-            # might have happened, that another worker created the links already.
-            # That isn't a problem though
-            haltOnFailure=False,
-            command=["sh", "-c", util.Interpolate(
-                "ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinkdest=symlinkdest, symlinksrc=symlinksrc)]))
+                "rm -vrf %(kw:symlinksrc)s && mkdir -p %(kw:symlinksrc)s && ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
 
     return f
 

--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -117,14 +117,14 @@ cat build/targets-%(prop:branch)s.txt \
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
     # TODO: This linking stuff does not work reliably
-    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:falterVersion)s/packages")
-    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/packages/%(prop:origbuildnumber)s")
-    f.addStep(
-        steps.MasterShellCommand(
-            name="change symlinks to new artifacts",
-            haltOnFailure=True,
-            command=["sh", "-c", util.Interpolate(
-                "rm -vrf %(kw:symlinksrc)s && ln -s  -T %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
+    #symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:falterVersion)s/packages")
+    #symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/packages/%(prop:origbuildnumber)s")
+    #f.addStep(
+    #    steps.MasterShellCommand(
+    #        name="change symlinks to new artifacts",
+    #        haltOnFailure=True,
+    #        command=["sh", "-c", util.Interpolate(
+    #            "rm -vrf %(kw:symlinksrc)s && ln -s  -T %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
 
     return f
 

--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -117,6 +117,31 @@ cat build/targets-%(prop:branch)s.txt \
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
 
+    # TODO: Make the following 3 steps better by having one symlink as the
+    # packages dir, not multiple within the packages dir.
+    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:falterVersion)s/packages/")
+    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/packages/%(prop:origbuildnumber)s/*")
+    f.addStep(
+        steps.MasterShellCommand(
+            name="remove symlinks to old artifacts",
+            haltOnFailure=True,
+            command=["sh", "-c", util.Interpolate(
+                "rm -vrf %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
+    f.addStep(
+        steps.MasterShellCommand(
+            name="recreate directory for symlinks",
+            haltOnFailure=True,
+            command=["sh", "-c", util.Interpolate(
+                "mkdir -p %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
+    f.addStep(
+        steps.MasterShellCommand(
+            name="symlink artifacts to url",
+            # might have happened, that another worker created the links already.
+            # That isn't a problem though
+            haltOnFailure=False,
+            command=["sh", "-c", util.Interpolate(
+                "ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinkdest=symlinkdest, symlinksrc=symlinksrc)]))
+
     return f
 
 # Runs build.sh with prop:arch and prop:branch, and uploads the result to master.
@@ -155,8 +180,6 @@ podman run -i --rm --timeout=1800 --log-driver=none docker.io/library/alpine:edg
     tarfile = util.Interpolate("packages-%(prop:origbuildnumber)s-%(prop:arch)s.tar")
     wwwpath = util.Interpolate("builds/packages/%(prop:origbuildnumber)s/%(prop:arch)s")
     wwwdir = util.Interpolate("/usr/local/src/www/htdocs/buildbot/%(kw:wwwpath)s", wwwpath=wwwpath)
-    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:falterVersion)s/packages/")
-    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/packages/%(prop:origbuildnumber)s/*")
     wwwurl = util.Interpolate("https://firmware.berlin.freifunk.net/%(kw:wwwpath)s", wwwpath=wwwpath)
     f.addStep(
         steps.FileUpload(
@@ -194,27 +217,5 @@ podman run -i --rm --timeout=1800 --log-driver=none docker.io/library/alpine:edg
             alwaysRun=True,
             warnOnFailure=False,
             command=["sh", "-c", "rm -vf out.tar"]))
-    # TODO: Make the following 3 steps better by having one symlink as the
-    # packages dir, not multiple within the packages dir.
-    f.addStep(
-        steps.MasterShellCommand(
-            name="remove symlinks to old artifacts",
-            haltOnFailure=True,
-            command=["sh", "-c", util.Interpolate(
-                "rm -vrf %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
-    f.addStep(
-        steps.MasterShellCommand(
-            name="recreate directory for symlinks",
-            haltOnFailure=True,
-            command=["sh", "-c", util.Interpolate(
-                "mkdir -p %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
-    f.addStep(
-        steps.MasterShellCommand(
-            name="symlink artifacts to url",
-            # might have happened, that another worker created the links already.
-            # That isn't a problem though
-            haltOnFailure=False,
-            command=["sh", "-c", util.Interpolate(
-                "ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinkdest=symlinkdest, symlinksrc=symlinksrc)]))
 
     return f

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -25,7 +25,7 @@ def targetsConfig(c):
         branch=util.StringParameter(
           name="branch",
           label="branch",
-          default="master"),
+          default="buildbot-new"),
         revision=util.FixedParameter(name="revision", default=""),
         repository=util.FixedParameter(name="repository", default=builter_repo),
         project=util.FixedParameter(name="project", default=""))],
@@ -111,30 +111,15 @@ done \
         steps.ShellCommand(
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
-    # TODO: Make the following 3 steps better by having one symlink as the
-    # packages dir, not multiple within the packages dir.
+    # TODO: This linking stuff does not work reliably...
     symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion)s/")
     symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/targets/%(prop:origbuildnumber)s/*")
     f.addStep(
         steps.MasterShellCommand(
-            name="remove symlinks to old artifacts",
+            name="change symlinks to new artifacts",
             haltOnFailure=True,
             command=["sh", "-c", util.Interpolate(
-                "rm -vrf %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
-    f.addStep(
-        steps.MasterShellCommand(
-            name="recreate directory for symlinks",
-            haltOnFailure=True,
-            command=["sh", "-c", util.Interpolate(
-                "mkdir -p %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
-    f.addStep(
-        steps.MasterShellCommand(
-            name="symlink artifacts to url",
-            # might have happened, that another worker created the links already.
-            # That isn't a problem though
-            haltOnFailure=False,
-            command=["sh", "-c", util.Interpolate(
-                "ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinkdest=symlinkdest, symlinksrc=symlinksrc)]))
+                "rm -vrf %(kw:symlinksrc)s && mkdir -p %(kw:symlinksrc)s && ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
 
     return f
 

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -2,6 +2,7 @@
 # ex: set filetype=python:
 
 from buildbot.plugins import *
+import re
 
 from asyncbuild import *
 
@@ -64,7 +65,10 @@ def targetTriggerStep(target):
       'branch': util.Interpolate("%(prop:branch)s"),
       'origbuildnumber': util.Interpolate("%(prop:buildnumber)s"),
       'virtual_builder_name': util.Interpolate("t/%(prop:branch)s/%(kw:target)s", target=target),
-      'virtual_builder_tags': ["targets", util.Interpolate("%(prop:branch)s")]})
+      'virtual_builder_tags': ["targets", util.Interpolate("%(prop:branch)s")],
+      #'falterVersion': util.Interpolate("%(prop:falterVersion)s")
+      'falterVersion': util.Interpolate("%(prop:release)s")
+      })
 
 # Fans out to one builder per target and blocks for the results.
 def targetsFactory(f):
@@ -107,6 +111,30 @@ done \
         steps.ShellCommand(
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
+    # TODO: Make the following 3 steps better by having one symlink as the
+    # packages dir, not multiple within the packages dir.
+    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion)s/")
+    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/targets/%(prop:origbuildnumber)s/*")
+    f.addStep(
+        steps.MasterShellCommand(
+            name="remove symlinks to old artifacts",
+            haltOnFailure=True,
+            command=["sh", "-c", util.Interpolate(
+                "rm -vrf %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
+    f.addStep(
+        steps.MasterShellCommand(
+            name="recreate directory for symlinks",
+            haltOnFailure=True,
+            command=["sh", "-c", util.Interpolate(
+                "mkdir -p %(kw:symlinksrc)s", symlinksrc=symlinksrc)]))
+    f.addStep(
+        steps.MasterShellCommand(
+            name="symlink artifacts to url",
+            # might have happened, that another worker created the links already.
+            # That isn't a problem though
+            haltOnFailure=False,
+            command=["sh", "-c", util.Interpolate(
+                "ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinkdest=symlinkdest, symlinksrc=symlinksrc)]))
 
     return f
 

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -112,14 +112,14 @@ done \
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
     # TODO: This linking stuff does not work reliably...
-    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion)s")
-    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/targets/%(prop:origbuildnumber)s")
-    f.addStep(
-        steps.MasterShellCommand(
-            name="change symlinks to new artifacts",
-            haltOnFailure=True,
-            command=["sh", "-c", util.Interpolate(
-                "rm -vrf %(kw:symlinksrc)s && ln -s -T %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
+    #symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion)s")
+    #symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/targets/%(prop:origbuildnumber)s")
+    #f.addStep(
+    #    steps.MasterShellCommand(
+    #        name="change symlinks to new artifacts",
+    #        haltOnFailure=True,
+    #        command=["sh", "-c", util.Interpolate(
+    #            "rm -vrf %(kw:symlinksrc)s && ln -s -T %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
 
     return f
 

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -112,14 +112,14 @@ done \
             name=util.Interpolate("%(prop:asyncSuccess)s of %(prop:asyncTotal)s succeeded"),
             command=["true"]))
     # TODO: This linking stuff does not work reliably...
-    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion)s/")
-    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/targets/%(prop:origbuildnumber)s/*")
+    symlinksrc = util.Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion)s")
+    symlinkdest = util.Interpolate("/usr/local/src/www/htdocs/buildbot/builds/targets/%(prop:origbuildnumber)s")
     f.addStep(
         steps.MasterShellCommand(
             name="change symlinks to new artifacts",
             haltOnFailure=True,
             command=["sh", "-c", util.Interpolate(
-                "rm -vrf %(kw:symlinksrc)s && mkdir -p %(kw:symlinksrc)s && ln -s %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
+                "rm -vrf %(kw:symlinksrc)s && ln -s -T %(kw:symlinkdest)s %(kw:symlinksrc)s", symlinksrc=symlinksrc, symlinkdest=symlinkdest)]))
 
     return f
 

--- a/roles/buildbot/templates/config.py.j2
+++ b/roles/buildbot/templates/config.py.j2
@@ -8,8 +8,9 @@ matrixRoom = '{{ matrixRoom }}'
 
 
 # Repository-URL for the builter script.
-builter_repo = 'https://github.com/freifunk-berlin/falter-builter.git'
-builter_branches = ['master']
+# TODO: bring changes in nice way into mainline repo
+builter_repo = 'https://github.com/Akira25/falter-builter.git'
+builter_branches = ['buildbot-new','master']
 
 
 # URL for the packages repo. The branches map to the branches selectable


### PR DESCRIPTION
Follow-up to #30 and #43, about publishing packages and targets to the appropriate `/feed`, `/unstable`, `/stable` directories.