### PR TITLE
buildbot-worker: Fix role

### DIFF
--- a/roles/buildbot_worker/handlers/main.yml
+++ b/roles/buildbot_worker/handlers/main.yml
@@ -5,6 +5,6 @@
     enabled: true
     state: restarted
 
-- name: Initialize buildbot-worker
+- name: Initialise buildbot-worker
   command: buildbot-worker create-worker --umask=0o22 {{ bbworker_path }} {{ bbmaster_fqdn }}:{{ bbmaster_port }} {{ bbworker_name }} {{ bbworker_pwd }}
   become_user: bbworker

--- a/roles/buildbot_worker/tasks/main.yml
+++ b/roles/buildbot_worker/tasks/main.yml
@@ -54,7 +54,7 @@
 
 - name: Add workers admin-info
   template:
-    dest: "{{ bbworker_path }}/info/admin"
+    dest: "{{ bbworker_path }}info/admin"
     src: admin.j2
     mode: "0644"
     owner: "{{ machine_user }}"
@@ -73,7 +73,8 @@
   ansible.builtin.file:
     path: "{{ bbworker_path }}"
     state: directory
-    mode: "0644"
+    # needs to be this high. Otherwise service will not start.
+    mode: "0755"
     owner: "{{ machine_user }}"
     group: "{{ machine_user }}"
     recurse: true


### PR DESCRIPTION
Minor fixes for buildbot-worker role. There was some misspelled handler and there needs to be a directory for the worker info files.

Signed-off-by: Martin Hübner <martin.hubner@web.de>