### PR TITLE
treewide. Disallow root-login on servers after provision.

### DIFF
--- a/play.yml
+++ b/play.yml
@@ -1,26 +1,20 @@
 ---
 # This playbook deploys the whole application stack in this site.
 
-- name: Apply common configuration
+- name: Deploy users to all servers
+  hosts: all
+  become: true
+  vars_files:
+    - inventory/group_vars/users
+  roles:
+    - ryandaniels.create_users
+  tags: user_provision
+
+- name: Apply common configuration and packagaes
   hosts: all,!c.tunnel.berlin.freifunk.net,!d.tunnel.berlin.freifunk.net
   become: true
-  vars_files:
-    - inventory/group_vars/users
   roles:
     - common
-    - ryandaniels.create_users
-  tags: basic_provision
-
-- name: Deploy Users to tunneldigger Ubuntu servers
-  hosts:
-    - c.tunnel.berlin.freifunk.net
-    - d.tunnel.berlin.freifunk.net
-  become: true
-  vars_files:
-    - inventory/group_vars/users
-  roles:
-    - ryandaniels.create_users
-  tags: basic_provision
 
 - name: Set up buildbot environment
   hosts: buildbot

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -15,3 +15,9 @@
     name: prometheus-node-exporter
     enabled: true
     state: restarted
+
+- name: Restart sshd
+  ansible.builtin.service:
+    name: sshd
+    enabled: true
+    state: restarted

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -55,3 +55,17 @@
     owner: root
     group: root
   notify: Restart prometheus-node-exporter
+
+- name: Disallow password-based login for all users
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: 'PasswordAuthentication'
+    line: 'PasswordAuthentication no'
+  notify: Restart sshd
+
+- name: Disallow login for root user
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: 'PermitRootLogin'
+    line: 'PermitRootLogin no'
+  notify: Restart sshd


### PR DESCRIPTION
This disallows root-login and pasword-based login on all servers. Fixes #54 

Signed-off-by: Martin Hübner <martin.hubner@web.de>