### PR TITLE
workflows: update checkout action to v3

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,11 +1,12 @@
+---
 name: Ansible Lint
-on: [push, pull_request]
+on: [push, pull_request]  # yamllint disable-line rule:truthy
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Create .vaultpass file
         run: echo "${{ secrets.VAULTPASS }}" > ./.vaultpass
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Lint Ansible Playbook
         uses: ansible/ansible-lint-action@main


### PR DESCRIPTION
v2 of the checkout action is deprecated and should therefore be replaced with v3.