### PR TITLE
workflows: add yaml-lint

### DIFF
--- a/.config/yaml-lint.yml
+++ b/.config/yaml-lint.yml
@@ -1,0 +1,20 @@
+---
+# This extends the default yaml-lint conf by adjusting some options.
+
+extends: default
+
+# ignore possible venv directory and encrypted ansible vault files in the worker directories
+ignore: |
+  venv
+  inventory/host_vars/buildbot-worker-*/main.yml
+
+rules:
+  comments:
+    level: error
+  comments-indentation:
+    level: error
+  document-start:
+    level: error
+  line-length:
+    max: 2048
+    level: warning

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,16 @@
+---
+name: Yaml Lint
+on: [push, pull_request]  # yamllint disable-line rule:truthy
+
+jobs:
+  build:
+    name: Yaml Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Lint Yaml Files
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .config/yaml-lint.yml


### PR DESCRIPTION
This adds yaml-lint to the workflow and ignores ansible vault files in the worker directories.