### PR TITLE
limit journald size to 1 gb

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -22,3 +22,9 @@
     name: sshd
     enabled: true
     state: restarted
+
+- name: Restart journald
+  ansible.builtin.service:
+    name: systemd-journald
+    enabled: true
+    state: restarted

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -69,3 +69,11 @@
     line: 'PermitRootLogin no'
     insertafter: EOF
   notify: Restart sshd
+
+- name: Set Journald Max Size to 1G
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/journald.conf
+    insertafter: '^#SystemMaxUse'
+    regexp: '^SystemMaxUse'
+    line: SystemMaxUse=1G
+  notify: Restart journald


### PR DESCRIPTION
Usually it will use ~4 GB

".. defaults to 10% .. of the size of the respective file system, but ...is capped to 4G. " (journald manpage)


This will limit its size down to 1 gb, which is enough in our usecase and limits the amount of data we store
