### PR TITLE
buildbot: do releases

### DIFF
--- a/roles/buildbot/files/master.cfg
+++ b/roles/buildbot/files/master.cfg
@@ -70,11 +70,11 @@ c['builders'] = []
 
 # see ./packages.py
 from packages import packagesConfig
-c = packagesConfig(c, packages_repo, packages_branches, workerNames)
+c = packagesConfig(c, packages_repo, packages_branches, workerNames, alpineVersion)
 
 # see ./targets.py
 from targets import targetsConfig
-c = targetsConfig(c, builter_repo, builter_branches, builter_releaseBranches, workerNames)
+c = targetsConfig(c, builter_repo, builter_branches, builter_releaseBranches, workerNames, alpineVersion)
 
 # see ./notify.py
 from notify import MatrixNotifier

--- a/roles/buildbot/templates/config.py.j2
+++ b/roles/buildbot/templates/config.py.j2
@@ -53,6 +53,10 @@ workerNames = [
 ]
 
 
+# Version of the Alpine Linux container: edge, 3.17, 3.16, ...
+alpineVersion = '3.17'
+
+
 # this variable holds all workers available. masterworker is somewhat special,
 # so we let appear it here only.
 workers = [


### PR DESCRIPTION
Adds a "force-release" button for building release images. Versions that contain "-" or "snapshot" go to /unstable, others go to /stable. More info in freifunk-berlin/falter-builter#134.

Also: remove the 9 hour timeout on targets builds, build times vary too much.