### PR TITLE
buildbot: fix builds

### DIFF
--- a/roles/buildbot/files/master.cfg
+++ b/roles/buildbot/files/master.cfg
@@ -118,52 +118,52 @@ c['schedulers'].append(AnyBranchScheduler(
     builderNames=["builds/packages"]))
 
 
-c['schedulers'].append(Nightly(
-    name="nightly-snapshot",
-    dayOfWeek=[0,3],
-    hour=0, # in local timezone of the host running buildbot
-    createAbsoluteSourceStamps=True,
-    onlyIfChanged=False,
-    builderNames=["builds/targets"],
-    codebases={"": {
-        "repository": config['builter_repo'],
-        "branch": config['builter_branches'][0],
-    }},
-    properties={
-        "falterBranch":"snapshot",
-        "falterVersion":"snapshot",
-    }))
+# c['schedulers'].append(Nightly(
+#     name="nightly-snapshot",
+#     dayOfWeek=[0,3],
+#     hour=0, # in local timezone of the host running buildbot
+#     createAbsoluteSourceStamps=True,
+#     onlyIfChanged=False,
+#     builderNames=["builds/targets"],
+#     codebases={"": {
+#         "repository": config['builter_repo'],
+#         "branch": config['builter_branches'][0],
+#     }},
+#     properties={
+#         "falterBranch":"snapshot",
+#         "falterVersion":"snapshot",
+#     }))
 
 
-c['schedulers'].append(Nightly(
-    name="nightly-1.4.0-snapshot",
-    dayOfWeek=[2,5],
-    hour=0, # in local timezone of the host running buildbot
-    createAbsoluteSourceStamps=True,
-    onlyIfChanged=False,
-    builderNames=["builds/targets"],
-    codebases={"": {
-        "repository": config['builter_repo'],
-        "branch": config['builter_branches'][0],
-    }},
-    properties={
-        "falterBranch":"1.4.0-snapshot",
-        "falterVersion":"1.4.0-snapshot",
-    }))
+# c['schedulers'].append(Nightly(
+#     name="nightly-1.4.0-snapshot",
+#     dayOfWeek=[2,5],
+#     hour=0, # in local timezone of the host running buildbot
+#     createAbsoluteSourceStamps=True,
+#     onlyIfChanged=False,
+#     builderNames=["builds/targets"],
+#     codebases={"": {
+#         "repository": config['builter_repo'],
+#         "branch": config['builter_branches'][0],
+#     }},
+#     properties={
+#         "falterBranch":"1.4.0-snapshot",
+#         "falterVersion":"1.4.0-snapshot",
+#     }))
 
 
-c['schedulers'].append(Nightly(
-    name="nightly-1.3.0-snapshot",
-    dayOfWeek=[1,4],
-    hour=0, # in local timezone of the host running buildbot
-    createAbsoluteSourceStamps=True,
-    onlyIfChanged=False,
-    builderNames=["builds/targets"],
-    codebases={"": {
-        "repository": config['builter_repo'],
-        "branch": config['builter_branches'][0],
-    }},
-    properties={
-        "falterBranch":"1.3.0-snapshot",
-        "falterVersion":"1.3.0-snapshot",
-    }))
+# c['schedulers'].append(Nightly(
+#     name="nightly-1.3.0-snapshot",
+#     dayOfWeek=[1,4],
+#     hour=0, # in local timezone of the host running buildbot
+#     createAbsoluteSourceStamps=True,
+#     onlyIfChanged=False,
+#     builderNames=["builds/targets"],
+#     codebases={"": {
+#         "repository": config['builter_repo'],
+#         "branch": config['builter_branches'][0],
+#     }},
+#     properties={
+#         "falterBranch":"1.3.0-snapshot",
+#         "falterVersion":"1.3.0-snapshot",
+#     }))

--- a/roles/buildbot/files/master.cfg
+++ b/roles/buildbot/files/master.cfg
@@ -114,7 +114,7 @@ c['schedulers'].append(AnyBranchScheduler(
     change_filter=filter.ChangeFilter(
         repository=config['packages_repo'].removesuffix('.git'),
         branch=config['packages_branches']),
-    # treeStableTimer=900,
+    treeStableTimer=900,
     builderNames=["builds/packages"]))
 
 

--- a/roles/buildbot/templates/config.py.j2
+++ b/roles/buildbot/templates/config.py.j2
@@ -43,7 +43,7 @@ config = {
     'packages_branches': ['master','openwrt-23.05','openwrt-22.03','openwrt-21.02','testbuildbot'],
 
     # Version of the Alpine Linux container: edge, 3.17, 3.16, ...
-    'alpineVersion': 'edge',
+    'alpineVersion': '3.18',
 
     # workernames get used in the build-factories, all workers get assigned to
     # the falter-builders except for the master worker


### PR DESCRIPTION
A few little fixes:

- buildbot: temporarily disable nightlies while broken
- buildbot: re-enable treeStableTimer
- buildbot: switch to alpine 3.18, edge has mkdir segfaults
