### PR TITLE
fixes for tunneldigger

### DIFF
--- a/play.yml
+++ b/play.yml
@@ -11,10 +11,11 @@
   tags: user_provision
 
 - name: Apply common configuration and packages
-  hosts: all,!d.tunnel.berlin.freifunk.net
+  hosts: all
   become: true
   roles:
     - common
+  tags: basics
 
 - name: Set up buildbot environment
   hosts: buildbot
@@ -51,7 +52,9 @@
     - ff_monitor
 
 - name: Set up tunneldigger
-  hosts: c.tunnel.berlin.freifunk.net,f.tunnel.berlin.freifunk.net
+  hosts: c.tunnel.berlin.freifunk.net,f.tunnel.berlin.freifunk.net,d.tunnel.berlin.freifunk.net
   become: true
   roles:
+    - tunneldigger
+  tags:
     - tunneldigger

--- a/roles/tunneldigger/defaults/main.yml
+++ b/roles/tunneldigger/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 tunneldigger_path: /opt/tunneldigger
-tunneldigger_listen_ip: "{{ ansible_eth0.ipv4.address }}"
+tunneldigger_listen_ip: "{{ ansible_default_ipv4.address }}"
 tunneldigger_snat_ip: "{{ tunneldigger_listen_ip }}"
 tunneldigger_oifname: "eth0"

--- a/roles/tunneldigger/handlers/main.yml
+++ b/roles/tunneldigger/handlers/main.yml
@@ -13,5 +13,10 @@
     enabled: true
     state: restarted
 
-- name: Load nftables rules
-  command: "/usr/sbin/nft -f /etc/nftables.conf"
+
+- name: Restart nftables
+  systemd:
+    daemon_reload: true
+    name: nftables
+    enabled: true
+    state: restarted

--- a/roles/tunneldigger/tasks/main.yml
+++ b/roles/tunneldigger/tasks/main.yml
@@ -7,6 +7,7 @@
       - gcc
       - git
       - iproute2
+      - iptables
       - libevent-dev
       - libnetfilter-conntrack-dev
       - libnfnetlink-dev
@@ -25,7 +26,7 @@
     mode: "0644"
     owner: root
     group: root
-  notify: Load nftables rules
+  notify: Restart nftables
 
 - name: Flush handlers
   meta: flush_handlers
@@ -45,7 +46,7 @@
   notify: Restart tunneldigger
 
 - name: Install tunneldigger in venv
-  shell: "source {{ tunneldigger_path }}/env/bin/activate && cd {{ tunneldigger_path }}/broker && python setup.py install"
+  shell: "source {{ tunneldigger_path }}/env/bin/activate && cd {{ tunneldigger_path }}/broker && pip install --upgrade setuptools && python setup.py install"
   args:
     creates: "{{ tunneldigger_path }}/broker/dist/"
     executable: /bin/bash

--- a/roles/tunneldigger/templates/l2tp_broker.cfg.j2
+++ b/roles/tunneldigger/templates/l2tp_broker.cfg.j2
@@ -6,7 +6,7 @@ address={{ tunneldigger_listen_ip }}
 ; port=8942
 port=8942
 ; Interface with that IP address
-interface=eth0
+interface={{ ansible_default_ipv4.interface }}
 ; Maximum number of tunnels that will be allowed by the broker
 max_tunnels=3991
 ; Tunnel port base. This port is not visible to clients, but must be free on the server.
@@ -30,8 +30,7 @@ pmtu=0
 ; Verbosity
 verbosity=DEBUG
 ; Should IP addresses be logged or not
-log_ip_addresses=true
-; todo changemeback
+log_ip_addresses=false
 
 [hooks]
 ; Note that hooks are called asynchonously!

--- a/roles/tunneldigger/templates/nftables.conf.j2
+++ b/roles/tunneldigger/templates/nftables.conf.j2
@@ -12,10 +12,10 @@ table ip nat {
 table ip filter {
         chain forward {
                 type filter hook forward priority filter; policy accept;
-                oifname "eth0" ip daddr 10.0.0.0/8 counter packets 0 bytes 0 reject with icmp type net-prohibited
-                oifname "eth0" ip daddr 172.16.0.0/12 counter packets 0 bytes 0 reject with icmp type net-prohibited
-                oifname "eth0" ip daddr 192.168.0.0/16 counter packets 0 bytes 0 reject with icmp type net-prohibited
-                oifname "eth0" ip daddr 169.254.0.0/16 counter packets 0 bytes 0 reject with icmp type net-prohibited
+                oifname "{{ ansible_default_ipv4.interface }}" ip daddr 10.0.0.0/8 counter packets 0 bytes 0 reject with icmp type net-prohibited
+                oifname "{{ ansible_default_ipv4.interface }}" ip daddr 172.16.0.0/12 counter packets 0 bytes 0 reject with icmp type net-prohibited
+                oifname "{{ ansible_default_ipv4.interface }}" ip daddr 192.168.0.0/16 counter packets 0 bytes 0 reject with icmp type net-prohibited
+                oifname "{{ ansible_default_ipv4.interface }}" ip daddr 169.254.0.0/16 counter packets 0 bytes 0 reject with icmp type net-prohibited
                 tcp flags syn tcp option maxseg size set rt mtu
         }
 }

--- a/roles/tunneldigger/templates/nftables.conf.j2
+++ b/roles/tunneldigger/templates/nftables.conf.j2
@@ -6,7 +6,7 @@ flush ruleset
 table ip nat {
         chain postrouting {
                 type nat hook postrouting priority srcnat; policy accept;
-                ip saddr 172.31.224.0/20 oif "eth0" snat to {{ tunneldigger_snat_ip }}
+                ip saddr 172.31.224.0/20 oif "{{ ansible_default_ipv4.interface }}" snat to {{ tunneldigger_snat_ip }}
         }
 }
 table ip filter {


### PR DESCRIPTION
the newly set-up d.tunnel is now using a minimal debian 12.

Therefore i added it to the "propper" hosts (e.g. remove expections)
I also added needed dependencies and tadded smaller fixes for hosts with Predictable Network Interface renaming