### PR TITLE
monitor: add new locations and gateway locations

### DIFF
--- a/roles/ff_monitor/templates/config.local.php.j2
+++ b/roles/ff_monitor/templates/config.local.php.j2
@@ -28,6 +28,7 @@
   $CONFIG['cat']['BBB-VPN'] = '/bbb-vpn/';
 
   # Locations in alphabetical order
+  $CONFIG['cat']['AK36'] = '/^ak36-/';
   $CONFIG['cat']['Andreas-Gymnasium'] = '/^agym-/i';
   $CONFIG['cat']['Berliner Hochschule für Technik (BHT)'] = '/^bht/i';
   $CONFIG['cat']['Cafe Wostok'] = '/^cafe-wostok-/i';
@@ -55,6 +56,7 @@
   $CONFIG['cat']['Halle'] = '/^halle-/i';
   $CONFIG['cat']['Haus Der Statistik'] = '/^hds|^hdm/i';
   $CONFIG['cat']['Hirschhof'] = '/^hirschhof-/i';
+  $CONFIG['cat']['J41'] = '/^j41-/';
   $CONFIG['cat']['JUP'] = '/^jup-/i';
   $CONFIG['cat']['Kastanienallee'] = '/^k12|^k11/i';
   $CONFIG['cat']['Kiehlufer'] = '/^kiehlufer/i';
@@ -63,6 +65,7 @@
   $CONFIG['cat']['Kosmos'] = '/^kosmos-/i';
   $CONFIG['cat']['Kts13'] = '/^kts13-/';
   $CONFIG['cat']['Kub'] = '/^kub-/';
+  $CONFIG['cat']['L105'] = '/^l105-/';
   $CONFIG['cat']['L5'] = '/^l5-/i';
   $CONFIG['cat']['Liese21'] = '/^liese-21-/i';
   $CONFIG['cat']['Linie206'] = '/^linie206/i';
@@ -72,6 +75,7 @@
   $CONFIG['cat']['Mahalle'] = '/^mahalle-/i';
   $CONFIG['cat']['Manstein10'] = '/^manstein10-/i';
   $CONFIG['cat']['Martin Luther Kirche'] = '/^mlk-nk-/';
+  $CONFIG['cat']['Ohlauer'] = '/^ohlauer-/';
   $CONFIG['cat']['Philmel'] = '/^philmel/i';
   $CONFIG['cat']['Potse'] = '/^potse-/';
   $CONFIG['cat']['Q216'] = '/^q216-/';
@@ -82,6 +86,7 @@
   $CONFIG['cat']['Rigaer83'] = '/^rigaer83/i';
   $CONFIG['cat']['Rio'] = '/^rio-/';
   $CONFIG['cat']['Rixbox'] = '/^rixbox/i';
+  $CONFIG['cat']['Saarbruecker'] = '/^saarbruecker-/';
   $CONFIG['cat']['Sama27'] = '/^sama27-/';
   $CONFIG['cat']['Samariterkirche'] = '/^sama-/';
   $CONFIG['cat']['Scharni'] = '/^scharni/';
@@ -91,9 +96,12 @@
   $CONFIG['cat']['Sgfrd'] = '/^sgfrd-/';
   $CONFIG['cat']['Simeon'] = '/^simeon/i';
   $CONFIG['cat']['Ska95'] = '/^ska95-/';
+  $CONFIG['cat']['Spitta13'] = '/^spitta13-/';
   $CONFIG['cat']['St.-Adalbert Kirche'] = '/^stadalbert-/i';
+  $CONFIG['cat']['Strom'] = '/^strom-/';
   $CONFIG['cat']['Technik Museum'] = '/^dtmb-/i';
   $CONFIG['cat']['Teufelsberg'] = '/^teufelsberg-/i';
+  $CONFIG['cat']['Torte'] = '/^torte-/';
   $CONFIG['cat']['Vaterhaus'] = '/^vaterhaus/i';
   $CONFIG['cat']['W38B'] = '/^w38b-/i';
   $CONFIG['cat']['Weidenbaum'] = '/^weidenbaum-|funkpilz|funkigel/';


### PR DESCRIPTION
this PR adds new locations and also adds the existing gateway locations for which we will have SNMP statistics once we flash the gateways with a firmware containing https://github.com/freifunk-berlin/bbb-configs/commit/9a676abaa1c8d5c72d903f818ce8ee2ac68aca5a