### PR TITLE
buildbot: need zstd for OpenWrt tarballs now

### DIFF
--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -236,7 +236,7 @@ def packagesArchFactory(f, wwwPrefix, wwwURL, alpineVersion):
                     """\
 podman run -i --rm --log-driver=none docker.io/library/alpine:%(kw:alpineVersion)s sh -c '\
 ( \
-    apk add git bash wget xz gzip unzip grep diffutils findutils coreutils build-base gcc abuild binutils ncurses-dev gawk bzip2 perl python3 rsync argp-standalone musl-fts-dev musl-obstack-dev musl-libintl \
+    apk add git bash wget zstd gzip unzip grep diffutils findutils coreutils build-base gcc abuild binutils ncurses-dev gawk bzip2 perl python3 rsync argp-standalone musl-fts-dev musl-obstack-dev musl-libintl \
     && git clone %(prop:repository)s /root/falter-packages \
     && cd /root/falter-packages/ \
     && git checkout %(prop:got_revision)s \

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -347,7 +347,7 @@ def targetsTargetFactory(f, wwwPrefix, wwwURL, alpineVersion):
                     """\
 podman run -i --rm --log-driver=none docker.io/library/alpine:%(kw:alpineVersion)s sh -c '\
 ( \
-    apk add git bash wget xz gzip unzip grep diffutils findutils coreutils build-base gcc abuild binutils ncurses-dev gawk bzip2 gettext perl python3 rsync sqlite flex libxslt \
+    apk add git bash wget zstd gzip unzip grep diffutils findutils coreutils build-base gcc abuild binutils ncurses-dev gawk bzip2 gettext perl python3 rsync sqlite flex libxslt \
     && git clone %(prop:repository)s /root/falter-builter \
     && cd /root/falter-builter/ \
     && git checkout %(prop:got_revision)s \

--- a/roles/buildbot/tasks/main.yml
+++ b/roles/buildbot/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install dependencies
   apt:
     name:
+      - zstd
       - build-essential
       - pkg-config
       - git

--- a/roles/podman_fix/tasks/main.yml
+++ b/roles/podman_fix/tasks/main.yml
@@ -1,9 +1,0 @@
----
-- name: Quick-fix alvistack.podman role by adding dbus-user-session
-  # This fix seems to be not the best, as it pulls roughly 20 MiB additional
-  # dependencies. https://github.com/alvistack/ansible-role-podman/issues/17#issuecomment-1352787379
-  apt:
-    name: dbus-user-session
-    state: present
-    update_cache: true
-    cache_valid_time: 3600


### PR DESCRIPTION
Removing xz-utils in favor of zstd.

Also removed the old temporary podman fix, and manually removed the related APT repositories. Fixes `apt update`.