### PR TITLE
buildbot: OpenWrt 24.10, and combined profiles.json for autoupdater

### DIFF
--- a/roles/buildbot/files/master.cfg
+++ b/roles/buildbot/files/master.cfg
@@ -59,8 +59,6 @@ c['www']['ui_default_config'] = {
     'Builders.page_size': 500,
     'Build.trigger_step_page_size': 100,
     'BuildRequests.buildrequestFetchLimit': 100,
-    'Home.max_recent_builds': 1, # broken?
-    'Home.max_recent_builders': 3, # broken?
 }
 
 c['change_source'] = []

--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -102,6 +102,7 @@ def archTriggerStep(arch):
 def branchToFalterBranch(props):
     o2f = {
         "main": "snapshot",
+        "openwrt-24.10": "1.5.0-snapshot",
         "openwrt-23.05": "1.4.0-snapshot",
         "openwrt-22.03": "1.3.0-snapshot",
         "openwrt-21.02": "1.2.3-snapshot",

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -246,6 +246,7 @@ cat build/targets-%(prop:falterBranch)s.txt \
         "%(kw:prefix)s/builds/targets/%(prop:buildnumber)s", prefix=wwwPrefix
     )
     pubdir = util.Interpolate("%(kw:pr)s/%(kw:pd)s", pr=wwwPrefix, pd=targetsPubDir)
+
     f.addStep(
         steps.MasterShellCommand(
             name="publish",
@@ -279,7 +280,9 @@ cat build/targets-%(prop:falterBranch)s.txt \
                     # since we want to be able to just delete that at any time,
                     # without worrying about symlinks pointing to deleted stuff.
                     """\
-mkdir -p %(kw:p)s %(kw:p)s.new \
+cat %(kw:w)s/tunneldigger/*/*/profiles.json | jq -s . > %(kw:w)s/tunneldigger/profiles.json \
+    && cat %(kw:w)s/notunnel/*/*/profiles.json | jq -s . > %(kw:w)s/notunnel/profiles.json \
+    && mkdir -p %(kw:p)s %(kw:p)s.new \
     && rm -rf %(kw:p)s.new/* %(kw:p)s.prev \
     && mv %(kw:w)s/* %(kw:p)s.new/ \
     && mv %(kw:p)s %(kw:p)s.prev \

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -167,6 +167,8 @@ def targetsFalterBranch(props):
         return "1.3.0-snapshot"
     elif fv.startswith("1.4.0"):
         return "1.4.0-snapshot"
+    elif fv.startswith("1.5.0"):
+        return "1.5.0-snapshot"
     else:
         return "snapshot"
 


### PR DESCRIPTION
This is to help the autoupdater with devices that changed target names - e.g. Nanostation ath79/generic to ath79/tiny

(plus OpenWrt 24.10, and a little fix for an upcoming upgrade to Buildbot 4.x)