### PR TITLE
buildbot: apply variant to tarball upload, avoid race condition

### DIFF
--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -310,8 +310,10 @@ cat %(kw:w)s/tunneldigger/*/*/profiles.json | jq -s . > %(kw:w)s/tunneldigger/pr
 
 @util.renderer
 def targetsTarFile(props):
+    n = props["origbuildnumber"]
     t, st = props["target"].split("/")
-    return "targets-{0}-{1}_{2}.tar".format(props["origbuildnumber"], t, st)
+    v = props["variant"]
+    return "targets-{0}-{1}-{2}-{3}.tar".format(n, t, st, v)
 
 
 def targetsTargetFactory(f, wwwPrefix, wwwURL, alpineVersion):


### PR DESCRIPTION
One more little fix :)

After building, the workers upload the results to buildbot as a tarball file. The filename includes target and the ID of the original parent build. With 0fa146a, there are now two builds of the same target (notunnel & tunneldigger) and with the right timing they can delete each other's upload.

Fix this by including the variant in the upload tarball filename.