### PR TITLE
owm2meshviewer: fix missing olsr config

### DIFF
--- a/roles/ff_util/files/owm2meshviewer.py
+++ b/roles/ff_util/files/owm2meshviewer.py
@@ -364,7 +364,8 @@ def process_node_json(comment, body, ignore_if_offline=True):
                 for link in owmnode["links"]
                 if "sourceAddr4" in link
             ]
-            node_addresses.append(owmnode["olsr"]["ipv4Config"]["config"]["mainIp"])
+            if "config" in owmnode["olsr"]["ipv4Config"]:
+                node_addresses.append(owmnode["olsr"]["ipv4Config"]["config"]["mainIp"])
         except KeyError:
             pass
         # Deduplicate list


### PR DESCRIPTION
fix error
roles/ff_util/files/owm2meshviewer.py", line 365, in process_node_json
    node_addresses.append(owmnode["olsr"]["ipv4Config"]["config"]["mainIp"])
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: string indices must be integers, not 'str'