### PR TITLE
buildbot: update mirror options

### DIFF
--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -249,7 +249,7 @@ sudo podman run -i --rm --log-driver=none --network=slirp4netns --tmpfs /root:rw
     && git checkout %(prop:got_revision)s \
     && git submodule init \
     && git submodule update \
-    && env OPENWRT_MIRROR=%(kw:owMirror)s FALTER_MIRROR=%(kw:fMirror)s build/build.sh %(prop:branch)s %(prop:arch)s out/ \
+    && env OPENWRT_MIRROR=%(kw:owMirror)s FALTER_MIRROR=%(kw:fMirror)s GIT_MIRROR=%(kw:gitMirror)s SOURCES_MIRROR=%(kw:srcMirror)s build/build.sh %(prop:branch)s %(prop:arch)s out/ \
     && rm -vf out/%(prop:branch)s/%(prop:arch)s/public-key.pem \
 ) >&2 \
 && cd /root/falter-packages/out/ \
@@ -258,6 +258,8 @@ sudo podman run -i --rm --log-driver=none --network=slirp4netns --tmpfs /root:rw
                     alpineVersion=config['alpineVersion'],
                     owMirror=config['openwrtMirror'],
                     fMirror=config['falterMirror'],
+                    gitMirror=config['gitMirror'],
+                    srcMirror=config['sourcesMirror'],
                 ),
             ],
         )

--- a/roles/buildbot/templates/config.py.j2
+++ b/roles/buildbot/templates/config.py.j2
@@ -42,8 +42,10 @@ config = {
     'packages_repo': 'https://github.com/freifunk-berlin/falter-packages.git',
     'packages_branches': ['main','openwrt-25.12','openwrt-24.10','openwrt-23.05','openwrt-22.03','openwrt-21.02','testbuildbot'],
 
-    'openwrtMirror': 'https://mirror.berlin.freifunk.net/downloads.openwrt.org',
+    'openwrtMirror': '',
     'falterMirror': '',
+    'gitMirror': '',
+    'sourcesMirror': '',
 
     # Version of the Alpine Linux container: edge, 3.17, 3.16, ...
     # TODO: we're currently stuck at 3.18 because 3.19+ have a segfault:


### PR DESCRIPTION
We just use the defaults for now, but I still want the up-to-date options present