### PR TITLE
buildbot: big targets on fast workers & reliable stopping

### DIFF
--- a/roles/buildbot/files/master.cfg
+++ b/roles/buildbot/files/master.cfg
@@ -24,6 +24,8 @@
 # https://docs.buildbot.net/3.6.0/manual/configuration/builders.html
 #
 
+import random
+
 from datetime import timedelta
 from config import config
 
@@ -80,6 +82,13 @@ def makeWorker(w):
         return worker.Worker(w['name'], w['password'], **args)
 workers = [makeWorker(w) for w in config['workers']]
 bmc['workers'] = [worker.LocalWorker('masterworker', max_builds=1)] + workers
+
+def selectNextWorker(builder, workers, buildreq):
+    for wfb in workers:
+        if 'fast' in wfb.worker.properties.getProperty('tags', []):
+            return wfb
+    return random.choice(workers)
+bmc['select_next_worker'] = selectNextWorker
 
 bmc['change_source'] = []
 bmc['services'] = []

--- a/roles/buildbot/files/packages.py
+++ b/roles/buildbot/files/packages.py
@@ -241,6 +241,7 @@ def packagesArchFactory(f, config):
                     #     https://github.com/containers/podman/issues/13779
                     #
                     """\
+trap "podman kill -a ; rm -f out.tar" TERM ; \
 %(prop:podmanCmd)s run -i --rm --pids-limit=0 --log-driver=none --network=slirp4netns --tmpfs /root:rw,size=12582912k,mode=1777 docker.io/library/alpine:%(kw:alpineVersion)s sh -c '\
 ( \
     apk add git bash wget zstd xz gzip unzip grep diffutils findutils coreutils build-base gcc abuild binutils ncurses-dev gawk bzip2 perl python3 rsync argp-standalone musl-fts-dev musl-obstack-dev musl-libintl py3-setuptools \

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -237,8 +237,10 @@ targets=$(for t in $(cat build/targets-%(prop:falterBranch)s.txt \
 | grep -v "#" | grep . \
 | cut -d" " -f2- | xargs -n1 echo | sort) ; do echo "$t tunneldigger" ; echo "$t notunnel" ; done) \
 ; echo "$targets" | grep "ath79/generic" \
+; echo "$targets" | grep "ipq40xx/generic" \
+; echo "$targets" | grep "mediatek/filogic" \
 ; echo "$targets" | grep "ramips/mt7621" \
-; echo "$targets" | grep -v "ath79/generic" | grep -v "ramips/mt7621" \
+; echo "$targets" | grep -v "ath79/generic" | grep -v "ipq40xx/generic" | grep -v "mediatek/filogic" | grep -v "ramips/mt7621" \
 """
                 ),
             ],

--- a/roles/buildbot/files/targets.py
+++ b/roles/buildbot/files/targets.py
@@ -353,6 +353,7 @@ def targetsTargetFactory(f, config):
                     # Also larger targets seemed to need more than 6 GiB.
                     #
                     """\
+trap "podman kill -a ; rm -f out.tar" TERM ; \
 %(prop:podmanCmd)s run -i --rm --log-driver=none --pids-limit=0 --network=slirp4netns --tmpfs /root:rw,size=12582912k,mode=1777 docker.io/library/alpine:%(kw:alpineVersion)s sh -c '\
 ( \
     apk add git bash wget zstd xz gzip unzip grep diffutils findutils coreutils build-base gcc abuild binutils ncurses-dev gawk bzip2 gettext perl python3 rsync sqlite flex libxslt py3-setuptools \


### PR DESCRIPTION
When big targets are assigned to slower workers, the overall build can easily take 3x longer. Prioritize fast workers and big targets in a way that draws them to each other. We currently have 8 fast workers and 8 big targets (4*2), so it fits nicely.

Also make sure that when a build is stopped/cancelled, its container gets stopped reliably. It used to be, but at some point we started leaking containers.