### PR TITLE
Switch domain for meshviewer

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -31,7 +31,7 @@ meshtastic
 meshtastic.berlin.freifunk.net
 
 [utils]
-util.berlin.freifunk.net # hopglass
+util.berlin.freifunk.net # map
 
 [download]
 download-master.berlin.freifunk.net

--- a/play.yml
+++ b/play.yml
@@ -82,7 +82,7 @@
   tags:
     - wiki
 
-- name: Set up hopglass
+- name: Set up meshviewer/util
   hosts: utils
   become: true
   roles:

--- a/roles/ff_monitor/files/create_node_geojson.py
+++ b/roles/ff_monitor/files/create_node_geojson.py
@@ -15,7 +15,7 @@ for node in dhcp_leases.json()['data']['result']:
     LEASES_DICT[node_name] = leases
 
 
-with urllib.request.urlopen("https://hopglass.berlin.freifunk.net/meshviewer.json") as url:
+with urllib.request.urlopen("https://map.berlin.freifunk.net/meshviewer.json") as url:
     data = json.loads(url.read().decode())
 
     simplenodelist = list()

--- a/roles/ff_monitor/files/create_node_list.py
+++ b/roles/ff_monitor/files/create_node_list.py
@@ -2,7 +2,7 @@
 import json
 import urllib.request
 
-with urllib.request.urlopen("https://hopglass.berlin.freifunk.net/meshviewer.json") as url:
+with urllib.request.urlopen("https://map.berlin.freifunk.net/meshviewer.json") as url:
     data = json.loads(url.read().decode())
 
     simplenodelist = list()

--- a/roles/ff_monitor/files/firmwaremetrics/index.php
+++ b/roles/ff_monitor/files/firmwaremetrics/index.php
@@ -6,7 +6,7 @@
 require_once('classify-firmware.php');
 header("Content-Type: text/plain");
 
-$url="https://hopglass.berlin.freifunk.net/meshviewer.json";
+$url="https://map.berlin.freifunk.net/meshviewer.json";
 //  Initiate curl
 $ch = curl_init();
 // Will return the response, if false it print the response

--- a/roles/ff_util/README.md
+++ b/roles/ff_util/README.md
@@ -1,5 +1,5 @@
 # ff_util
 
-Small baserole to prepare the hopglass/util server.
+Small baserole to prepare the meshviewer/util server.
 
 There are some manual steps in here, please look at the [tasks/main.yml]

--- a/roles/ff_util/files/cron_d_meshviewer
+++ b/roles/ff_util/files/cron_d_meshviewer
@@ -10,5 +10,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # |  |  |  |  |
 # *  *  *  *  * user-name command to be executed
 
-*/10 *  *  *  *  caddy cd /opt/meshviewer/; /opt/meshviewer/venv/bin/python3 /opt/meshviewer/owm2meshviewer.py; mv /opt/meshviewer/nodes_meshviewer.json /var/www/hopglass.berlin.freifunk.net/www/meshviewer.json
+*/10 *  *  *  *  caddy cd /opt/meshviewer/; /opt/meshviewer/venv/bin/python3 /opt/meshviewer/owm2meshviewer.py; mv /opt/meshviewer/nodes_meshviewer.json /var/www/map.berlin.freifunk.net/www/meshviewer.json
 

--- a/roles/ff_util/files/meshviewer_config.json
+++ b/roles/ff_util/files/meshviewer_config.json
@@ -2,7 +2,7 @@
   "cacheBreaker": "2f967a527",
   "clientZoom": 15,
   "dataPath": [
-    "https://hopglass.berlin.freifunk.net/"
+    "https://map.berlin.freifunk.net/"
   ],
   "deprecated": [
     "TP-Link Archer C2 v3",
@@ -39,7 +39,7 @@
   ],
   "deprecation_enabled": true,
   "deprecation_text": "Dieses Gerät ist relativ alt und sollte bei Gelegenheit getauscht werden - <a href='https://berlin.freifunk.net/de/contact/'>Melde dich jetzt bei uns</a>",
-  "devicePictures": "https://hopglass.berlin.freifunk.net/device-pictures/{MODEL_NORMALIZED}.svg",
+  "devicePictures": "https://map.berlin.freifunk.net/device-pictures/{MODEL_NORMALIZED}.svg",
   "devicePicturesLicense": "CC-BY-NC-SA 4.0",
   "devicePicturesSource": "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
   "domainNames": [

--- a/roles/ff_util/files/owm2meshviewer.py
+++ b/roles/ff_util/files/owm2meshviewer.py
@@ -15,7 +15,7 @@ import requests
 # This is a quick hack to pull Freifunk node data for a specific geographic area
 # from OpenWifiMap (OWM) and to convert it to the format used by Gluon communities
 # typically (ffmap-backend, nodes.json and graph.json) in order to be able to use
-# it with compatible frontends such as HopGlass.
+# it with compatible frontends such as meshviewer.
 
 # The cache is mostly helpful when debugging the script.
 # Use /dev/shm ramdisk since that's much faster than real disks on shared VMs

--- a/roles/ff_util/handlers/main.yml
+++ b/roles/ff_util/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Unpack Meshviewer
   ansible.builtin.unarchive:
     src: /opt/meshviewer/meshviewer-build.zip
-    dest: /var/www/hopglass.berlin.freifunk.net/www
+    dest: /var/www/map.berlin.freifunk.net/www
     remote_src: true

--- a/roles/ff_util/tasks/main.yml
+++ b/roles/ff_util/tasks/main.yml
@@ -8,7 +8,7 @@
     group: caddy
   loop:
     - /opt/meshviewer
-    - /var/www/hopglass.berlin.freifunk.net/www/
+    - /var/www/map.berlin.freifunk.net/www/
 
 - name: Download Meshviewer release
   ansible.builtin.get_url:
@@ -30,7 +30,7 @@
 - name: Copy meshviewer config
   ansible.builtin.copy:
     src: meshviewer_config.json
-    dest: /var/www/hopglass.berlin.freifunk.net/www/config.json
+    dest: /var/www/map.berlin.freifunk.net/www/config.json
     mode: "0644"
     owner: caddy
     group: caddy
@@ -61,5 +61,5 @@
   become_user: caddy
   ansible.builtin.git:
     repo: https://github.com/freifunk/device-pictures.git
-    dest: /var/www/hopglass.berlin.freifunk.net/device-pictures
+    dest: /var/www/map.berlin.freifunk.net/device-pictures
     version: main

--- a/templates/Caddyfile_utils.j2
+++ b/templates/Caddyfile_utils.j2
@@ -13,11 +13,11 @@
     }
 }
 
-hopglass.berlin.freifunk.net {
+map.berlin.freifunk.net {
     handle_path /device-pictures/* {
-        root /var/www/hopglass.berlin.freifunk.net/device-pictures/pictures-svg/
+        root /var/www/map.berlin.freifunk.net/device-pictures/pictures-svg/
     }
-    root * /var/www/hopglass.berlin.freifunk.net/www/
+    root * /var/www/map.berlin.freifunk.net/www/
     file_server browse
     encode gzip zstd
     header {

--- a/templates/Caddyfile_utils.j2
+++ b/templates/Caddyfile_utils.j2
@@ -25,6 +25,10 @@ map.berlin.freifunk.net {
     }
 }
 
+hopglass.berlin.freifunk.net {
+    redir https://map.berlin.freifunk.net permanent
+}
+
 https:// {
     encode gzip zstd
     uri path_regexp /{2,} /


### PR DESCRIPTION
I just updated the install steps. The old meshviewer installation will still exist in the old webroot. I would just remove that by hand afterwards and run the owm2meshviewer script manually. Or should this be included in in the tasks as explicit migration?

Anything I missed?

(The linting errors are unrelated to these changes and out of scope for this pr, see https://github.com/freifunk-berlin/ansible/pull/215)